### PR TITLE
feat: add single get api

### DIFF
--- a/app/Http/Controllers/BaseController.php
+++ b/app/Http/Controllers/BaseController.php
@@ -19,13 +19,29 @@ abstract class BaseController extends Controller
         if (empty($this->getModelClass())) {
             throw new \Exception('Please define your model class in controller.');
         }
-        
+
         $this->modelClass = $this->getModelClass();
     }
 
     public function index()
     {
         return $this->modelClass::all();
+    }
+
+    /**
+     * @param int $id
+     * @return Model
+     */
+    public function get(int $id)
+    {
+        /** @var Model $record */
+        $record = $this->modelClass::find($id);
+
+        if (empty($record)) {
+            throw new HttpException(404, 'Record not found.');
+        }
+
+        return $record;
     }
 
     /**

--- a/app/Http/Controllers/BaseController.php
+++ b/app/Http/Controllers/BaseController.php
@@ -59,7 +59,7 @@ abstract class BaseController extends Controller
             return new Response($validator->errors(), Response::HTTP_BAD_REQUEST);
         }
 
-        return $this->modelClass::create($request->toArray());
+        return $this->modelClass::create($request->toArray())->fresh();
     }
 
     /**

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -4,11 +4,28 @@ namespace App\Models;
 
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Validation\Rule;
 
+/**
+ * Class Item
+ * @package App\Models
+ *
+ * @property int $id
+ * @property string $code
+ * @property string $ean
+ * @property int $item_type_id
+ * @property int $inventory_unit_id
+ * @property double $weight
+ * @property int $weight_unit_id
+ * @property boolean $lot_controlled
+ */
 class Item extends Model
 {
     const TABLE = 'item';
 
+    /**
+     * @return array
+     */
     public function getAttributeDefaultValues(): array
     {
         return [
@@ -16,12 +33,16 @@ class Item extends Model
         ];
     }
 
+    /**
+     * @param string $scenario
+     * @return array
+     */
     public function getRules(string $scenario): array
     {
         $rules = [
             self::SCENARIO_CREATE => [
                 'code'              => ['required', 'max:20', "unique:{$this->table}"],
-                'ean'               => ['nullable', 'max:13'],
+                'ean'               => ['nullable', 'max:13', "unique:{$this->table}"],
                 'description'       => ['nullable', 'max:100'],
                 'item_type_id'      => ['required', 'exists:' . ItemType::TABLE . ',id'],
                 'inventory_unit_id' => ['required', 'exists:' . Unit::TABLE . ',id'],
@@ -29,7 +50,15 @@ class Item extends Model
                 'weight_unit_id'    => ['required', 'exists:' . Unit::TABLE . ',id'],
                 'lot_controlled'    => ['required', 'boolean'],
             ],
-            self::SCENARIO_UPDATE => [],
+            self::SCENARIO_UPDATE => [
+                'ean'               => ['nullable', 'max:13', Rule::unique($this->table)->ignore($this->id)],
+                'description'       => ['nullable', 'max:100'],
+                'item_type_id'      => ['exists:' . ItemType::TABLE . ',id'],
+                'inventory_unit_id' => ['exists:' . Unit::TABLE . ',id'],
+                'weight'            => ['numeric'],
+                'weight_unit_id'    => ['exists:' . Unit::TABLE . ',id'],
+                'lot_controlled'    => ['boolean'],
+            ],
         ];
 
         return $scenario
@@ -50,7 +79,15 @@ class Item extends Model
                 'weight_unit_id',
                 'lot_controlled',
             ],
-            self::SCENARIO_UPDATE => [],
+            self::SCENARIO_UPDATE => [
+                'ean',
+                'description',
+                'item_type_id',
+                'inventory_unit_id',
+                'weight',
+                'weight_unit_id',
+                'lot_controlled',
+            ],
         ];
 
         return $fillable[$this->scenario];
@@ -58,6 +95,9 @@ class Item extends Model
 
     // Relationships
 
+    /**
+     * @return BelongsTo
+     */
     public function itemType(): BelongsTo
     {
         return $this->belongsTo(ItemType::class);

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -53,11 +53,11 @@ class Item extends Model
             self::SCENARIO_UPDATE => [
                 'ean'               => ['nullable', 'max:13', Rule::unique($this->table)->ignore($this->id)],
                 'description'       => ['nullable', 'max:100'],
-                'item_type_id'      => ['exists:' . ItemType::TABLE . ',id'],
-                'inventory_unit_id' => ['exists:' . Unit::TABLE . ',id'],
-                'weight'            => ['numeric'],
-                'weight_unit_id'    => ['exists:' . Unit::TABLE . ',id'],
-                'lot_controlled'    => ['boolean'],
+                'item_type_id'      => ['required', 'exists:' . ItemType::TABLE . ',id'],
+                'inventory_unit_id' => ['required', 'exists:' . Unit::TABLE . ',id'],
+                'weight'            => ['required', 'numeric'],
+                'weight_unit_id'    => ['required', 'exists:' . Unit::TABLE . ',id'],
+                'lot_controlled'    => ['required', 'boolean'],
             ],
         ];
 

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -23,9 +23,6 @@ class Item extends Model
 {
     const TABLE = 'item';
 
-    /**
-     * @return array
-     */
     public function getAttributeDefaultValues(): array
     {
         return [
@@ -33,10 +30,6 @@ class Item extends Model
         ];
     }
 
-    /**
-     * @param string $scenario
-     * @return array
-     */
     public function getRules(string $scenario): array
     {
         $rules = [

--- a/app/Models/ItemType.php
+++ b/app/Models/ItemType.php
@@ -26,10 +26,10 @@ class ItemType extends Model
     {
         $rules = [
             self::SCENARIO_CREATE => [
-                'description' => ['required', "unique:{$this->table}"],
+                'description' => ['required', 'max:30', "unique:{$this->table}"],
             ],
             self::SCENARIO_UPDATE => [
-                'description' => ['required', Rule::unique($this->table)->ignore($this->id)],
+                'description' => ['required', 'max:30', Rule::unique($this->table)->ignore($this->id)],
             ],
         ];
 

--- a/app/Models/ItemType.php
+++ b/app/Models/ItemType.php
@@ -6,6 +6,13 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Validation\Rule;
 
+/**
+ * Class ItemType
+ * @package App\Models
+ *
+ * @property int $id
+ * @property string $description
+ */
 class ItemType extends Model
 {
     const TABLE = 'item_type';
@@ -22,7 +29,7 @@ class ItemType extends Model
                 'description' => ['required', "unique:{$this->table}"],
             ],
             self::SCENARIO_UPDATE => [
-                'description' => Rule::unique($this->table)->ignore($this->id),
+                'description' => ['required', Rule::unique($this->table)->ignore($this->id)],
             ],
         ];
 
@@ -41,6 +48,9 @@ class ItemType extends Model
         return $fillable[$this->scenario];
     }
 
+    /**
+     * @return HasMany
+     */
     public function items(): HasMany
     {
         return $this->hasMany(Item::class);

--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -25,6 +25,11 @@ abstract class Model extends \Illuminate\Database\Eloquent\Model
     const CREATED_AT = 'created_datetime';
     const UPDATED_AT = 'updated_datetime';
 
+    /**
+     * Model constructor.
+     * @param array $attributes
+     * @throws \Exception
+     */
     public function __construct(array $attributes = [])
     {
         if (empty(static::TABLE)) {
@@ -35,6 +40,9 @@ abstract class Model extends \Illuminate\Database\Eloquent\Model
         parent::__construct($attributes);
     }
 
+    /**
+     * @param string $scenario
+     */
     public function setScenario(string $scenario): void
     {
         if (!$this->isValidScenario($scenario)) {
@@ -44,11 +52,18 @@ abstract class Model extends \Illuminate\Database\Eloquent\Model
         $this->scenario = $scenario;
     }
 
+    /**
+     * @param string $scenario
+     * @return bool
+     */
     public function isValidScenario(string $scenario): bool
     {
         return in_array($scenario, $this->getScenarios());
     }
 
+    /**
+     * @return array
+     */
     public function getScenarios(): array
     {
         if ($this->scenarios) {
@@ -85,7 +100,14 @@ abstract class Model extends \Illuminate\Database\Eloquent\Model
         return $model;
     }
 
+    /**
+     * @param string $scenario
+     * @return array
+     */
     abstract public function getRules(string $scenario): array;
 
+    /**
+     * @return array
+     */
     abstract public function getAttributeDefaultValues(): array;
 }

--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -2,7 +2,14 @@
 
 namespace App\Models;
 
-
+/**
+ * Class Unit
+ * @package App\Models
+ *
+ * @property int $id
+ * @property string $code
+ * @property string $description
+ */
 class Unit extends Model
 {
     const TABLE = 'unit';

--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -20,7 +20,7 @@ class Unit extends Model
                 'description' => ['required', 'max:40'],
             ],
             self::SCENARIO_UPDATE => [
-                'description' => ['max:40'],
+                'description' => ['required', 'max:40'],
             ],
         ];
 

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -11,6 +11,10 @@
 |
 */
 
+use App\Constants\Service;
+use Illuminate\Database\Events\StatementPrepared;
+use Illuminate\Events\Dispatcher;
+
 if (!$basePath = realpath(__DIR__ . '/../')) {
     throw new \Exception('Your base path configuration is not correct.');
 }
@@ -19,6 +23,14 @@ $app = new \App\Application($basePath);
 $app->withFacades();
 
 $app->withEloquent();
+
+// Change PDO fetch mode. Since Laravel does not allow to change this via config anymore.
+$dispatcher = new Dispatcher();
+$dispatcher->listen(StatementPrepared::class, function ($event) {
+    $event->statement->setFetchMode(PDO::FETCH_ASSOC);
+});
+
+$app->make(Service::DB)->setEventDispatcher($dispatcher);
 
 /*
 |--------------------------------------------------------------------------

--- a/database/seeds/ItemControllerSeeder.php
+++ b/database/seeds/ItemControllerSeeder.php
@@ -14,6 +14,7 @@ class ItemControllerSeeder extends Seeder
             [
                 'id'                => 1,
                 'code'              => 'item-1',
+                'ean'               => '1234567890123',
                 'description'       => 'item-1 desc',
                 'item_type_id'      => 1,
                 'inventory_unit_id' => 1,

--- a/database/seeds/ItemControllerSeeder.php
+++ b/database/seeds/ItemControllerSeeder.php
@@ -4,11 +4,25 @@ namespace App\Database\Seeds;
 
 
 use App\Models\Item;
+use App\Models\ItemType;
+use App\Models\Unit;
 
 class ItemControllerSeeder extends Seeder
 {
     public function run()
     {
+        $this->db->table(Unit::TABLE)->delete();
+        $this->db->table(Unit::TABLE)->insert([
+            ['id' => 1, 'code' => 'un1', 'description' => 'un1 desc'],
+            ['id' => 2, 'code' => 'un2', 'description' => 'un2 desc'],
+        ]);
+
+        $this->db->table(ItemType::TABLE)->delete();
+        $this->db->table(ItemType::TABLE)->insert([
+            ['id' => 1, 'description' => 'type 1'],
+            ['id' => 2, 'description' => 'type 2'],
+        ]);
+
         $this->db->table(Item::TABLE)->delete();
         $this->db->table(Item::TABLE)->insert([
             [

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,6 +27,7 @@ $controllers = [
 foreach ($controllers as $resource => $controller) {
     $baseName = class_basename($controller);
     $router->get("/{$resource}", "{$baseName}@index");
+    $router->get("/{$resource}/{id}", "{$baseName}@get");
     $router->post("/{$resource}", "{$baseName}@create");
     $router->put("/{$resource}/{id}", "{$baseName}@update");
     $router->delete("/{$resource}/{id}", "{$baseName}@delete");

--- a/tests/api/BaseCest.php
+++ b/tests/api/BaseCest.php
@@ -3,7 +3,62 @@
 namespace App\Tests\Api;
 
 
+use ApiTester;
+use App\Constants\Service;
+use App\Tests\ValidationMessage;
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Support\Facades\Facade;
+
 abstract class BaseCest
 {
+    /** @var DatabaseManager */
+    protected $db;
+
     abstract protected function getBaseUrl(): string;
+
+    public function __construct()
+    {
+        $this->db = Facade::getFacadeApplication()->make(Service::DB);
+    }
+
+    /**
+     * Common verification steps when updating resource with missing required fields data
+     *
+     * @param ApiTester $I
+     * @param string $table
+     * @param string $url
+     * @param array $fields
+     * @param int $id
+     */
+    protected function testUpdateMissingRequiredFields(ApiTester $I, string $table, string $url, array $fields, int $id)
+    {
+        $before = $I->grabRecord($table, ['id' => $id]);
+
+        $I->sendPUT($url, []);
+
+        $I->seeResponseCodeIs(400);
+        $response = $I->grabJsonResponse();
+        verify($response['status'])->equals('fail');
+        foreach ($fields as $field) {
+            verify($response['data'])->hasKey($field);
+            verify($response['data'][$field])->contains(sprintf(ValidationMessage::REQUIRED, str_replace('_', ' ', $field)));
+        }
+        $after = $I->grabRecord($table, ['id' => $id]);
+        verify($before)->equals($after);
+    }
+
+    protected function testDelete(ApiTester $I, string $table, string $url, int $id)
+    {
+        $before = $I->grabRecord($table, ['id' => $id]);
+
+        $I->sendDELETE($url);
+
+        $I->seeResponseCodeIs(200);
+        $I->dontSeeInDatabase($table, $before);
+        $I->seeResponseIsJson();
+        $I->seeResponseContainsJson([
+            'status' => 'success',
+            'data'   => $before,
+        ]);
+    }
 }

--- a/tests/api/BaseCest.php
+++ b/tests/api/BaseCest.php
@@ -21,20 +21,177 @@ abstract class BaseCest
         $this->db = Facade::getFacadeApplication()->make(Service::DB);
     }
 
+    protected function testList(ApiTester $I, string $table)
+    {
+        $rows = $this->db->table($table)->get()->toArray();
+
+        $I->sendGET($this->getBaseUrl());
+
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseContainsJson([
+            'status' => 'success',
+            'data'   => $rows,
+        ]);
+    }
+
+    /**
+     * @param ApiTester $I
+     * @param string $table
+     * @param int $id
+     */
+    protected function testGet(ApiTester $I, string $table, int $id)
+    {
+        $row = $I->grabRecord($table, ['id' => $id]);
+
+        $I->sendGET("{$this->getBaseUrl()}/{$id}");
+
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseContainsJson([
+            'status' => 'success',
+            'data'   => $row,
+        ]);
+    }
+
+    protected function testCreate(ApiTester $I, string $table, array $fields, array $defaultFields)
+    {
+        $numOfRecord = $I->grabNumRecords($table);
+
+        $I->sendPOST($this->getBaseUrl(), $fields);
+
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseContainsJson([
+            'status' => 'success',
+            'data'   => array_merge($fields, $defaultFields),
+        ]);
+        $I->seeNumRecords($numOfRecord + 1, $table);
+        $response = $I->grabJsonResponse();
+        $row = $I->grabRecord($table, ['id' => $response['data']['id']]);
+        verify($response['data'])->equals($row);
+    }
+
+    /**
+     * @param ApiTester $I
+     * @param string $table
+     * @param array $fields
+     */
+    protected function testCreateWithTooLong(ApiTester $I, string $table, array $fields)
+    {
+        $numOfRecord = $I->grabNumRecords($table);
+        $data = array_fill_keys(array_keys($fields), str_repeat('super long', max($fields)));
+
+        $I->sendPOST($this->getBaseUrl(), $data);
+
+        $I->seeResponseCodeIs(400);
+        $response = $I->grabJsonResponse();
+        verify($response['status'])->equals('fail');
+        foreach ($fields as $field => $max) {
+            verify($response['data'])->hasKey($field);
+            verify($response['data'][$field])->contains(sprintf(ValidationMessage::MAX_STRING, $field, $max));
+        }
+        $I->seeNumRecords($numOfRecord, $table);
+    }
+
+    /**
+     * @param ApiTester $I
+     * @param string $table
+     * @param array $fields
+     */
+    protected function testCreateWithAlreadyExist(ApiTester $I, string $table, array $fields)
+    {
+        $numOfRecord = $I->grabNumRecords($table);
+
+        $I->sendPOST($this->getBaseUrl(), $fields);
+
+        $I->seeResponseCodeIs(400);
+        $response = $I->grabJsonResponse();
+        verify($response['status'])->equals('fail');
+        foreach ($fields as $field => $value) {
+            verify($response['data'])->hasKey($field);
+            verify($response['data'][$field])->contains(sprintf(ValidationMessage::UNIQUE, str_replace('_', ' ', $field)));
+        }
+        $I->seeNumRecords($numOfRecord, $table);
+    }
+
+    /**
+     * @param ApiTester $I
+     * @param string $table
+     * @param array $fields
+     */
+    protected function createWithMissingRequiredFields(ApiTester $I, string $table, array $fields)
+    {
+        $numOfRecord = $I->grabNumRecords($table);
+
+        $I->sendPOST($this->getBaseUrl(), []);
+
+        $I->seeResponseCodeIs(400);
+        $response = $I->grabJsonResponse();
+        verify($response['status'])->equals('fail');
+        foreach ($fields as $field) {
+            verify($response['data'])->hasKey($field);
+            verify($response['data'][$field])->contains(sprintf(ValidationMessage::REQUIRED, str_replace('_', ' ', $field)));
+        }
+        $I->seeNumRecords($numOfRecord, $table);
+    }
+
+    /**
+     * @param ApiTester $I
+     * @param string $table
+     * @param array $fields
+     */
+    protected function testCreateWithNonExistenceReference(ApiTester $I, string $table, array $fields)
+    {
+        $numOfRecord = $I->grabNumRecords($table);
+        $data = array_fill_keys($fields, 0);
+
+        $I->sendPOST($this->getBaseUrl(), $data);
+
+        $I->seeResponseCodeIs(400);
+        $response = $I->grabJsonResponse();
+        verify($response['status'])->equals('fail');
+        foreach ($fields as $field) {
+            verify($response['data'])->hasKey($field);
+            verify($response['data'][$field])->contains(sprintf(ValidationMessage::EXIST, str_replace('_', ' ', $field)));
+        }
+        $I->seeNumRecords($numOfRecord, $table);
+    }
+
+    /**
+     * @param ApiTester $I
+     * @param string $table
+     * @param array $fields
+     * @param int $id
+     */
+    protected function testUpdate(ApiTester $I, string $table, array $fields, int $id)
+    {
+        $before = $I->grabRecord($table, ['id' => $id]);
+
+        $I->sendPUT("{$this->getBaseUrl()}/{$id}", $fields);
+
+        $I->seeResponseCodeIs(200);
+        $after = $I->grabRecord($table, ['id' => $id]);
+        $I->seeResponseContainsJson([
+            'status' => 'success',
+            'data'   => $after,
+        ]);
+        verify($before)->notEquals($after);
+        foreach ($fields as $field => $value) {
+            verify($after[$field])->equals($value);
+        }
+    }
+
     /**
      * Common verification steps when updating resource with missing required fields data
      *
      * @param ApiTester $I
      * @param string $table
-     * @param string $url
      * @param array $fields
      * @param int $id
      */
-    protected function testUpdateMissingRequiredFields(ApiTester $I, string $table, string $url, array $fields, int $id)
+    protected function testUpdateWithMissingRequiredFields(ApiTester $I, string $table, array $fields, int $id)
     {
         $before = $I->grabRecord($table, ['id' => $id]);
 
-        $I->sendPUT($url, []);
+        $I->sendPUT("{$this->getBaseUrl()}/{$id}", []);
 
         $I->seeResponseCodeIs(400);
         $response = $I->grabJsonResponse();
@@ -47,11 +204,149 @@ abstract class BaseCest
         verify($before)->equals($after);
     }
 
-    protected function testDelete(ApiTester $I, string $table, string $url, int $id)
+    /**
+     * @param ApiTester $I
+     * @param string $table
+     * @param array $updateData
+     * @param array $fields
+     * @param int $id
+     */
+    protected function testUpdateWithInvalidFieldTypes(ApiTester $I, string $table, array $updateData, array $fields, int $id)
     {
         $before = $I->grabRecord($table, ['id' => $id]);
 
-        $I->sendDELETE($url);
+        $I->sendPUT("{$this->getBaseUrl()}/{$id}", $updateData + $before);
+
+        $I->seeResponseCodeIs(400);
+        $response = $I->grabJsonResponse();
+        verify($response['status'])->equals('fail');
+        foreach ($fields as $field => $message) {
+            verify($response['data'])->hasKey($field);
+            verify($response['data'][$field])->contains(sprintf($message, str_replace('_', ' ', $field)));
+        }
+        $after = $I->grabRecord($table, ['id' => $id]);
+        verify($before)->equals($after);
+    }
+
+    /**
+     * @param ApiTester $I
+     * @param string $table
+     * @param array $fields
+     * @param int $id
+     */
+    protected function testUpdateWithNonExistenceReference(ApiTester $I, string $table, array $fields, int $id)
+    {
+        $before = $I->grabRecord($table, ['id' => $id]);
+        $updateData = array_fill_keys($fields, 0);
+
+        $I->sendPUT("{$this->getBaseUrl()}/{$id}", $updateData + $before);
+
+        $I->seeResponseCodeIs(400);
+        $response = $I->grabJsonResponse();
+        verify($response['status'])->equals('fail');
+        foreach ($fields as $field) {
+            verify($response['data'])->hasKey($field);
+            verify($response['data'][$field])->contains(sprintf(ValidationMessage::EXIST, str_replace('_', ' ', $field)));
+        }
+        $after = $I->grabRecord($table, ['id' => $id]);
+        verify($before)->equals($after);
+    }
+
+    /**
+     * @param ApiTester $I
+     * @param string $table
+     * @param array $fields
+     * @param int $id
+     */
+    protected function testUpdateWithTooLong(ApiTester $I, string $table, array $fields, int $id)
+    {
+        $before = $I->grabRecord($table, ['id' => $id]);
+        $updateData = array_fill_keys(array_keys($fields), str_repeat('super long', max($fields)));
+
+        $I->sendPUT("{$this->getBaseUrl()}/{$id}", $updateData + $before);
+
+        $I->seeResponseCodeIs(400);
+        $response = $I->grabJsonResponse();
+        verify($response['status'])->equals('fail');
+        foreach ($fields as $field => $max) {
+            verify($response['data'])->hasKey($field);
+            verify($response['data'][$field])->contains(sprintf(ValidationMessage::MAX_STRING, $field, $max));
+        }
+        $after = $I->grabRecord($table, ['id' => $id]);
+        verify($before)->equals($after);
+    }
+
+    /**
+     * @param ApiTester $I
+     * @param string $table
+     * @param array $fields
+     * @param int $id
+     */
+    protected function testUpdateWithNullableFields(ApiTester $I, string $table, array $fields, int $id)
+    {
+        $before = $I->grabRecord($table, ['id' => $id]);
+        $updateData = array_fill_keys($fields, null);
+
+        $I->sendPUT("{$this->getBaseUrl()}/{$id}", $updateData + $before);
+
+        $I->seeResponseCodeIs(200);
+        $response = $I->grabJsonResponse();
+        verify($response['status'])->equals('success');
+        $after = $I->grabRecord($table, ['id' => $id]);
+        verify($before)->notEquals($after);
+        foreach ($fields as $field) {
+            verify($response['data'][$field])->null();
+            verify($after[$field])->null();
+        }
+    }
+
+    /**
+     * @param ApiTester $I
+     * @param string $table
+     * @param int $id
+     */
+    protected function testUpdateWithoutChangingUniqueFields(ApiTester $I, string $table, int $id)
+    {
+        $before = $I->grabRecord($table, ['id' => $id]);
+
+        $I->sendPUT("{$this->getBaseUrl()}/{$id}", $before);
+
+        $I->seeResponseCodeIs(200);
+        $response = $I->grabJsonResponse();
+        verify($response['status'])->equals('success');
+    }
+
+    /**
+     * @param ApiTester $I
+     * @param string $table
+     * @param array $fields
+     * @param int $id
+     */
+    protected function testUpdateWithUnfillableFields(ApiTester $I, string $table, array $fields, int $id)
+    {
+        $before = $I->grabRecord($table, ['id' => $id]);
+
+        $I->sendPUT("{$this->getBaseUrl()}/{$id}", $fields + $before);
+
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseContainsJson([
+            'status' => 'success',
+            'data'   => $before,
+        ]);
+        $after = $I->grabRecord($table, ['id' => $id]);
+        verify($before)->equals($after);
+    }
+
+    /**
+     * @param ApiTester $I
+     * @param string $table
+     * @param int $id
+     */
+    protected function testDelete(ApiTester $I, string $table, int $id)
+    {
+        $before = $I->grabRecord($table, ['id' => $id]);
+
+        $I->sendDELETE("{$this->getBaseUrl()}/{$id}");
 
         $I->seeResponseCodeIs(200);
         $I->dontSeeInDatabase($table, $before);

--- a/tests/api/BaseCest.php
+++ b/tests/api/BaseCest.php
@@ -5,5 +5,5 @@ namespace App\Tests\Api;
 
 abstract class BaseCest
 {
-    abstract public function getBaseUrl(): string;
+    abstract protected function getBaseUrl(): string;
 }

--- a/tests/api/BaseControllerCest.php
+++ b/tests/api/BaseControllerCest.php
@@ -12,12 +12,12 @@ use App\Database\Seeds\UnitControllerSeeder;
  */
 class BaseControllerCest extends BaseCest
 {
-    public function getBaseUrl(): string
+    protected function getBaseUrl(): string
     {
         return '/units';
     }
 
-    public function deleteNonExistentUnit(ApiTester $I)
+    public function testDeleteNonExistentUnit(ApiTester $I)
     {
         (new UnitControllerSeeder)->run();
         $I->sendDELETE("{$this->getBaseUrl()}/99");
@@ -28,7 +28,7 @@ class BaseControllerCest extends BaseCest
         ]);
     }
 
-    public function updateNonExistentUnit(ApiTester $I)
+    public function testUpdateNonExistenceResource(ApiTester $I)
     {
         (new UnitControllerSeeder)->run();
         $I->sendPUT("{$this->getBaseUrl()}/99", [

--- a/tests/api/ItemCest.php
+++ b/tests/api/ItemCest.php
@@ -41,12 +41,15 @@ class ItemCest extends BaseCest
 
         $I->sendPOST($this->getBaseUrl(), [
             'code' => 'item-1',
+            'ean'  => '1234567890123',
         ]);
 
         $response = $I->grabJsonResponse();
         verify($response['status'])->equals('fail');
-        verify($response['data'])->hasKey('code');
-        verify($response['data']['code'])->contains(sprintf(ValidationMessage::UNIQUE, 'code'));
+        foreach (['code', 'ean'] as $field) {
+            verify($response['data'])->hasKey($field);
+            verify($response['data'][$field])->contains(sprintf(ValidationMessage::UNIQUE, str_replace('_', ' ', $field)));
+        }
         $I->seeNumRecords($numOfRecord, Item::TABLE);
     }
 
@@ -108,5 +111,119 @@ class ItemCest extends BaseCest
             verify($response['data'][$field])->contains(sprintf($message, str_replace('_', ' ', $field)));
         }
         $I->seeNumRecords($numOfRecord, Item::TABLE);
+    }
+
+    public function updateItemWithUnFillableFields(ApiTester $I)
+    {
+        (new ItemControllerSeeder)->run();
+        $before = $I->grabRecord(Item::TABLE, ['id' => 1]);
+
+        $I->sendPUT("{$this->getBaseUrl()}/1", [
+                'code' => 'some string',
+            ] + $before
+        );
+
+        $after = $I->grabRecord(Item::TABLE, ['id' => 1]);
+        verify($before)->equals($after);
+    }
+
+    public function updateItemWithoutChangingUniqueField(ApiTester $I)
+    {
+        (new ItemControllerSeeder)->run();
+        $before = $I->grabRecord(Item::TABLE, ['id' => 1]);
+
+        $I->sendPUT("{$this->getBaseUrl()}/1", $before);
+
+        $response = $I->grabJsonResponse();
+        verify($response['status'])->equals('success');
+    }
+
+    public function updateNullableFieldsWithNull(ApiTester $I)
+    {
+        (new ItemControllerSeeder)->run();
+        $before = $I->grabRecord(Item::TABLE, ['id' => 1]);
+
+        $I->sendPUT("{$this->getBaseUrl()}/1", [
+                'ean'         => null,
+                'description' => null,
+            ] + $before
+        );
+
+        $I->seeResponseContainsJson([
+            'status' => 'success',
+            'data'   => [
+                'ean'         => null,
+                'description' => null,
+            ],
+        ]);
+        $after = $I->grabRecord(Item::TABLE, ['id' => 1]);
+        verify($before)->notEquals($after);
+        verify($after['ean'])->null();
+        verify($after['description'])->null();
+    }
+
+    public function updateItemWithTooLong(ApiTester $I)
+    {
+        (new ItemControllerSeeder)->run();
+        $before = $I->grabRecord(Item::TABLE, ['id' => 1]);
+
+        $I->sendPUT("{$this->getBaseUrl()}/1", [
+                'ean'         => str_repeat('super long', 100),
+                'description' => str_repeat('super long', 100),
+            ] + $before
+        );
+
+        $response = $I->grabJsonResponse();
+        verify($response['status'])->equals('fail');
+        foreach (['ean' => 13, 'description' => 100] as $field => $max) {
+            verify($response['data'])->hasKey($field);
+            verify($response['data'][$field])->contains(sprintf(ValidationMessage::MAX_STRING, $field, $max));
+        }
+        $after = $I->grabRecord(Item::TABLE, ['id' => 1]);
+        verify($before)->equals($after);
+    }
+
+    public function updateItemWithNonExistenceReference(ApiTester $I)
+    {
+        (new ItemControllerSeeder)->run();
+        $before = $I->grabRecord(Item::TABLE, ['id' => 1]);
+
+        $I->sendPUT("{$this->getBaseUrl()}/1", [
+                'item_type_id'      => 99,
+                'inventory_unit_id' => 99,
+                'weight_unit_id'    => 99,
+            ] + $before
+        );
+
+        $response = $I->grabJsonResponse();
+        verify($response['status'])->equals('fail');
+        foreach (['item_type_id', 'inventory_unit_id', 'weight_unit_id'] as $field) {
+            verify($response['data'])->hasKey($field);
+            verify($response['data'][$field])->contains(sprintf(ValidationMessage::EXIST, str_replace('_', ' ', $field)));
+        }
+        $after = $I->grabRecord(Item::TABLE, ['id' => 1]);
+        verify($before)->equals($after);
+    }
+
+    public function updateItemWithInvalidFieldTypes(ApiTester $I)
+    {
+        (new ItemControllerSeeder)->run();
+        $before = $I->grabRecord(Item::TABLE, ['id' => 1]);
+
+        $I->sendPUT("{$this->getBaseUrl()}/1", [
+                'weight'         => 'some string',
+                'lot_controlled' => 'some string',
+            ] + $before
+        );
+
+        $response = $I->grabJsonResponse();
+        verify($response['status'])->equals('fail');
+        $fields = ['weight' => ValidationMessage::NUMERIC, 'lot_controlled' => ValidationMessage::BOOLEAN];
+        foreach ($fields as $field => $message) {
+            verify($response['data'])->hasKey($field);
+            verify($response['data'][$field])->contains(sprintf($message, str_replace('_', ' ', $field)));
+        }
+        $after = $I->grabRecord(Item::TABLE, ['id' => 1]);
+        verify($before)->equals($after);
     }
 }

--- a/tests/api/ItemCest.php
+++ b/tests/api/ItemCest.php
@@ -15,150 +15,80 @@ class ItemCest extends BaseCest
         return '/items';
     }
 
-    public function testGetItems(ApiTester $I)
+    public function testListItems(ApiTester $I)
     {
         (new ItemControllerSeeder)->run();
-
-        $I->sendGET($this->getBaseUrl());
-        $I->seeResponseCodeIs(200);
-        $I->seeResponseContainsJson([
-            'status' => 'success',
-            'data'   => [
-                [
-                    'id'                => 1,
-                    'code'              => 'item-1',
-                    'ean'               => '1234567890123',
-                    'description'       => 'item-1 desc',
-                    'item_type_id'      => 1,
-                    'inventory_unit_id' => 1,
-                    'weight'            => '0',
-                    'weight_unit_id'    => 1,
-                    'lot_controlled'    => 0,
-                    'created_datetime'  => '2018-01-01 00:00:00',
-                    'updated_datetime'  => '2018-01-01 00:00:00',
-                ],
-            ],
-        ]);
+        $this->testList($I, Item::TABLE);
     }
 
     public function testGetItem(ApiTester $I)
     {
         (new ItemControllerSeeder)->run();
-        $row = $I->grabRecord(Item::TABLE, ['id' => 1]);
-
-        $I->sendGET("{$this->getBaseUrl()}/1");
-        $I->seeResponseCodeIs(200);
-        $I->seeResponseContainsJson([
-            'status' => 'success',
-            'data'   => $row,
-        ]);
+        $this->testGet($I, Item::TABLE, 1);
     }
 
     public function testCreateItem(ApiTester $I)
     {
         (new ItemControllerSeeder)->run();
-        $numOfRecord = $I->grabNumRecords(Item::TABLE);
         $data = [
             'code'              => 'valid-item',
             'ean'               => '1122334455123',
             'description'       => 'valid-item desc',
             'item_type_id'      => 1,
             'inventory_unit_id' => 1,
-            'weight'            => '0',
+            'weight'            => 0,
             'weight_unit_id'    => 1,
-            'lot_controlled'    => 0,
+            'lot_controlled'    => 1,
         ];
+        $this->testCreate($I, Item::TABLE, $data, []);
+    }
 
-        $I->sendPOST($this->getBaseUrl(), $data);
-
-        $I->seeResponseCodeIs(200);
-        $I->seeResponseContainsJson([
-            'status' => 'success',
-            'data'   => $data,
-        ]);
-        $I->seeNumRecords($numOfRecord + 1, Item::TABLE);
+    public function testCreateItemWithDefaultValues(ApiTester $I)
+    {
+        (new ItemControllerSeeder)->run();
+        $data = [
+            'code'              => 'valid-item',
+            'ean'               => '1122334455123',
+            'description'       => 'valid-item desc',
+            'item_type_id'      => 1,
+            'inventory_unit_id' => 1,
+            'weight'            => 0,
+            'weight_unit_id'    => 1,
+        ];
+        $this->testCreate($I, Item::TABLE, $data, ['lot_controlled' => 0]);
     }
 
     public function testCreateItemWithMissingRequiredFields(ApiTester $I)
     {
         (new ItemControllerSeeder)->run();
-        $numOfRecord = $I->grabNumRecords(Item::TABLE);
-
-        $I->sendPOST($this->getBaseUrl(), []);
-
-        $I->seeResponseCodeIs(400);
-        $response = $I->grabJsonResponse();
-        verify($response['status'])->equals('fail');
-        verify(array_keys($response['data']))->equals([
+        $this->createWithMissingRequiredFields($I, Item::TABLE, [
             'code',
             'item_type_id',
             'inventory_unit_id',
             'weight',
             'weight_unit_id',
         ]);
-        $I->seeNumRecords($numOfRecord, Item::TABLE);
     }
 
     public function testCreateItemWithAlreadyExistCode(ApiTester $I)
     {
         (new ItemControllerSeeder)->run();
-        $numOfRecord = $I->grabNumRecords(Item::TABLE);
-
-        $I->sendPOST($this->getBaseUrl(), [
+        $this->testCreateWithAlreadyExist($I, Item::TABLE, [
             'code' => 'item-1',
             'ean'  => '1234567890123',
         ]);
-
-        $I->seeResponseCodeIs(400);
-        $response = $I->grabJsonResponse();
-        verify($response['status'])->equals('fail');
-        foreach (['code', 'ean'] as $field) {
-            verify($response['data'])->hasKey($field);
-            verify($response['data'][$field])->contains(sprintf(ValidationMessage::UNIQUE, str_replace('_', ' ', $field)));
-        }
-        $I->seeNumRecords($numOfRecord, Item::TABLE);
     }
 
-    public function tesstCreateItemWithTooLong(ApiTester $I)
+    public function testCreateItemWithTooLong(ApiTester $I)
     {
         (new ItemControllerSeeder)->run();
-        $numOfRecord = $I->grabNumRecords(Item::TABLE);
-
-        $I->sendPOST($this->getBaseUrl(), [
-            'code'        => str_repeat('super long', 100),
-            'ean'         => str_repeat('super long', 100),
-            'description' => str_repeat('super long', 100),
-        ]);
-
-        $I->seeResponseCodeIs(400);
-        $response = $I->grabJsonResponse();
-        verify($response['status'])->equals('fail');
-        foreach (['code' => 20, 'ean' => 13, 'description' => 100] as $field => $max) {
-            verify($response['data'])->hasKey($field);
-            verify($response['data'][$field])->contains(sprintf(ValidationMessage::MAX_STRING, $field, $max));
-        }
-        $I->seeNumRecords($numOfRecord, Item::TABLE);
+        $this->testCreateWithTooLong($I, Item::TABLE, ['code' => 20, 'ean' => 13, 'description' => 100]);
     }
 
     public function testCreateItemWithNonExistenceReference(ApiTester $I)
     {
         (new ItemControllerSeeder)->run();
-        $numOfRecord = $I->grabNumRecords(Item::TABLE);
-
-        $I->sendPOST($this->getBaseUrl(), [
-            'item_type_id'      => 99,
-            'inventory_unit_id' => 99,
-            'weight_unit_id'    => 99,
-        ]);
-
-        $I->seeResponseCodeIs(400);
-        $response = $I->grabJsonResponse();
-        verify($response['status'])->equals('fail');
-        foreach (['item_type_id', 'inventory_unit_id', 'weight_unit_id'] as $field) {
-            verify($response['data'])->hasKey($field);
-            verify($response['data'][$field])->contains(sprintf(ValidationMessage::EXIST, str_replace('_', ' ', $field)));
-        }
-        $I->seeNumRecords($numOfRecord, Item::TABLE);
+        $this->testCreateWithNonExistenceReference($I, Item::TABLE, ['item_type_id', 'inventory_unit_id', 'weight_unit_id']);
     }
 
     public function testCreateItemWithInvalidFieldTypes(ApiTester $I)
@@ -185,42 +115,24 @@ class ItemCest extends BaseCest
     public function testUpdateItem(ApiTester $I)
     {
         (new ItemControllerSeeder)->run();
-        $before = $I->grabRecord(Item::TABLE, ['id' => 1]);
-
-        $I->sendPUT("{$this->getBaseUrl()}/1", [
-                'ean'               => '1234567890124',
-                'description'       => 'item-1 updated',
-                'item_type_id'      => 2,
-                'inventory_unit_id' => 2,
-                'weight'            => '20',
-                'weight_unit_id'    => 2,
-                'lot_controlled'    => 1,
-            ]
-        );
-
-        $I->seeResponseCodeIs(200);
-        $after = $I->grabRecord(Item::TABLE, ['id' => 1]);
-        $I->seeResponseContainsJson([
-            'status' => 'success',
-            'data'   => $after,
-        ]);
-        verify($before)->notEquals($after);
-        verify($after['ean'])->equals('1234567890124');
-        verify($after['description'])->equals('item-1 updated');
-        verify($after['item_type_id'])->equals(2);
-        verify($after['inventory_unit_id'])->equals(2);
-        verify($after['weight'])->equals(20);
-        verify($after['weight_unit_id'])->equals(2);
-        verify($after['lot_controlled'])->equals(1);
+        $updateData = [
+            'ean'               => '1234567890124',
+            'description'       => 'item-1 updated',
+            'item_type_id'      => 2,
+            'inventory_unit_id' => 2,
+            'weight'            => '20',
+            'weight_unit_id'    => 2,
+            'lot_controlled'    => 1,
+        ];
+        $this->testUpdate($I, Item::TABLE, $updateData, 1);
     }
 
     public function testUpdateItemWithMissingRequiredFields(ApiTester $I)
     {
         (new ItemControllerSeeder)->run();
-        $this->testUpdateMissingRequiredFields(
+        $this->testUpdateWithMissingRequiredFields(
             $I,
             Item::TABLE,
-            "{$this->getBaseUrl()}/1",
             ['item_type_id', 'inventory_unit_id', 'weight', 'weight_unit_id', 'lot_controlled'],
             1
         );
@@ -229,130 +141,47 @@ class ItemCest extends BaseCest
     public function testUpdateItemWithUnFillableFields(ApiTester $I)
     {
         (new ItemControllerSeeder)->run();
-        $before = $I->grabRecord(Item::TABLE, ['id' => 1]);
-
-        $I->sendPUT("{$this->getBaseUrl()}/1", [
-                'code' => 'some string',
-            ] + $before
-        );
-
-        $I->seeResponseCodeIs(200);
-        $I->seeResponseContainsJson([
-            'status' => 'success',
-            'data'   => $before,
-        ]);
-        $after = $I->grabRecord(Item::TABLE, ['id' => 1]);
-        verify($before)->equals($after);
+        $this->testUpdateWithUnfillableFields($I, Item::TABLE, ['code' => 'some string'], 1);
     }
 
     public function testUpdateItemWithoutChangingUniqueField(ApiTester $I)
     {
         (new ItemControllerSeeder)->run();
-        $before = $I->grabRecord(Item::TABLE, ['id' => 1]);
-
-        $I->sendPUT("{$this->getBaseUrl()}/1", $before);
-
-        $I->seeResponseCodeIs(200);
-        $response = $I->grabJsonResponse();
-        verify($response['status'])->equals('success');
+        $this->testUpdateWithoutChangingUniqueFields($I, Item::TABLE, 1);
     }
 
-    public function testUpdateNullableFieldsWithNull(ApiTester $I)
+    public function testUpdateItemWithNullableFields(ApiTester $I)
     {
         (new ItemControllerSeeder)->run();
-        $before = $I->grabRecord(Item::TABLE, ['id' => 1]);
-
-        $I->sendPUT("{$this->getBaseUrl()}/1", [
-                'ean'         => null,
-                'description' => null,
-            ] + $before
-        );
-
-        $I->seeResponseCodeIs(200);
-        $I->seeResponseContainsJson([
-            'status' => 'success',
-            'data'   => [
-                'ean'         => null,
-                'description' => null,
-            ],
-        ]);
-        $after = $I->grabRecord(Item::TABLE, ['id' => 1]);
-        verify($before)->notEquals($after);
-        verify($after['ean'])->null();
-        verify($after['description'])->null();
+        $this->testUpdateWithNullableFields($I, Item::TABLE, ['ean', 'description'], 1);
     }
 
     public function testUpdateItemWithTooLong(ApiTester $I)
     {
         (new ItemControllerSeeder)->run();
-        $before = $I->grabRecord(Item::TABLE, ['id' => 1]);
-
-        $I->sendPUT("{$this->getBaseUrl()}/1", [
-                'ean'         => str_repeat('super long', 100),
-                'description' => str_repeat('super long', 100),
-            ] + $before
-        );
-
-        $I->seeResponseCodeIs(400);
-        $response = $I->grabJsonResponse();
-        verify($response['status'])->equals('fail');
-        foreach (['ean' => 13, 'description' => 100] as $field => $max) {
-            verify($response['data'])->hasKey($field);
-            verify($response['data'][$field])->contains(sprintf(ValidationMessage::MAX_STRING, $field, $max));
-        }
-        $after = $I->grabRecord(Item::TABLE, ['id' => 1]);
-        verify($before)->equals($after);
+        $this->testUpdateWithTooLong($I, Item::TABLE, ['ean' => 13, 'description' => 100], 1);
     }
 
     public function testUpdateItemWithNonExistenceReference(ApiTester $I)
     {
         (new ItemControllerSeeder)->run();
-        $before = $I->grabRecord(Item::TABLE, ['id' => 1]);
-
-        $I->sendPUT("{$this->getBaseUrl()}/1", [
-                'item_type_id'      => 99,
-                'inventory_unit_id' => 99,
-                'weight_unit_id'    => 99,
-            ] + $before
-        );
-
-        $I->seeResponseCodeIs(400);
-        $response = $I->grabJsonResponse();
-        verify($response['status'])->equals('fail');
-        foreach (['item_type_id', 'inventory_unit_id', 'weight_unit_id'] as $field) {
-            verify($response['data'])->hasKey($field);
-            verify($response['data'][$field])->contains(sprintf(ValidationMessage::EXIST, str_replace('_', ' ', $field)));
-        }
-        $after = $I->grabRecord(Item::TABLE, ['id' => 1]);
-        verify($before)->equals($after);
+        $this->testUpdateWithNonExistenceReference($I, Item::TABLE, ['item_type_id', 'inventory_unit_id', 'weight_unit_id'], 1);
     }
 
     public function testUpdateItemWithInvalidFieldTypes(ApiTester $I)
     {
         (new ItemControllerSeeder)->run();
-        $before = $I->grabRecord(Item::TABLE, ['id' => 1]);
-
-        $I->sendPUT("{$this->getBaseUrl()}/1", [
-                'weight'         => 'some string',
-                'lot_controlled' => 'some string',
-            ] + $before
-        );
-
-        $I->seeResponseCodeIs(400);
-        $response = $I->grabJsonResponse();
-        verify($response['status'])->equals('fail');
+        $updateData = [
+            'weight'         => 'some string',
+            'lot_controlled' => 'some string',
+        ];
         $fields = ['weight' => ValidationMessage::NUMERIC, 'lot_controlled' => ValidationMessage::BOOLEAN];
-        foreach ($fields as $field => $message) {
-            verify($response['data'])->hasKey($field);
-            verify($response['data'][$field])->contains(sprintf($message, str_replace('_', ' ', $field)));
-        }
-        $after = $I->grabRecord(Item::TABLE, ['id' => 1]);
-        verify($before)->equals($after);
+        $this->testUpdateWithInvalidFieldTypes($I, Item::TABLE, $updateData, $fields, 1);
     }
 
     public function testDeleteItem(ApiTester $I)
     {
         (new ItemControllerSeeder)->run();
-        $this->testDelete($I, Item::TABLE, "{$this->getBaseUrl()}/1", 1);
+        $this->testDelete($I, Item::TABLE, 1);
     }
 }

--- a/tests/api/ItemCest.php
+++ b/tests/api/ItemCest.php
@@ -40,7 +40,7 @@ class ItemCest extends BaseCest
             'weight_unit_id'    => 1,
             'lot_controlled'    => 1,
         ];
-        $this->testCreate($I, Item::TABLE, $data, []);
+        $this->testCreate($I, Item::TABLE, $data);
     }
 
     public function testCreateItemWithDefaultValues(ApiTester $I)
@@ -61,7 +61,7 @@ class ItemCest extends BaseCest
     public function testCreateItemWithMissingRequiredFields(ApiTester $I)
     {
         (new ItemControllerSeeder)->run();
-        $this->createWithMissingRequiredFields($I, Item::TABLE, [
+        $this->testCreateWithMissingRequiredFields($I, Item::TABLE, [
             'code',
             'item_type_id',
             'inventory_unit_id',
@@ -94,22 +94,11 @@ class ItemCest extends BaseCest
     public function testCreateItemWithInvalidFieldTypes(ApiTester $I)
     {
         (new ItemControllerSeeder)->run();
-        $numOfRecord = $I->grabNumRecords(Item::TABLE);
-
-        $I->sendPOST($this->getBaseUrl(), [
+        $messages = ['weight' => ValidationMessage::NUMERIC, 'lot_controlled' => ValidationMessage::BOOLEAN];
+        $this->testCreateWithInvalidFieldTypes($I, Item::TABLE, [
             'weight'         => 'some string',
             'lot_controlled' => 'some string',
-        ]);
-
-        $I->seeResponseCodeIs(400);
-        $response = $I->grabJsonResponse();
-        verify($response['status'])->equals('fail');
-        $fields = ['weight' => ValidationMessage::NUMERIC, 'lot_controlled' => ValidationMessage::BOOLEAN];
-        foreach ($fields as $field => $message) {
-            verify($response['data'])->hasKey($field);
-            verify($response['data'][$field])->contains(sprintf($message, str_replace('_', ' ', $field)));
-        }
-        $I->seeNumRecords($numOfRecord, Item::TABLE);
+        ], $messages);
     }
 
     public function testUpdateItem(ApiTester $I)

--- a/tests/api/ItemTypeCest.php
+++ b/tests/api/ItemTypeCest.php
@@ -5,7 +5,6 @@ namespace App\Tests\Api;
 use ApiTester;
 use App\Database\Seeds\ItemTypeControllerSeeder;
 use App\Models\ItemType;
-use App\Tests\ValidationMessage;
 
 class ItemTypeCest extends BaseCest
 {
@@ -14,89 +13,38 @@ class ItemTypeCest extends BaseCest
         return '/item_types';
     }
 
-    public function testGetItemTypes(ApiTester $I)
+    public function testListItemTypes(ApiTester $I)
     {
         (new ItemTypeControllerSeeder)->run();
-
-        $I->sendGET($this->getBaseUrl());
-
-        $I->seeResponseCodeIs(200);
-        $I->seeResponseIsJson();
-        $I->seeResponseContainsJson([
-            'status' => 'success',
-            'data'   => [
-                ['id' => 1, 'description' => 'type 1'],
-                ['id' => 2, 'description' => 'type 2'],
-            ],
-        ]);
+        $this->testList($I, ItemType::TABLE);
     }
 
     public function testGetItemType(ApiTester $I)
     {
         (new ItemTypeControllerSeeder)->run();
-        $row = $I->grabRecord(ItemType::TABLE, ['id' => 1]);
-
-        $I->sendGET("{$this->getBaseUrl()}/1");
-
-        $I->seeResponseCodeIs(200);
-        $I->seeResponseIsJson();
-        $I->seeResponseContainsJson([
-            'status' => 'success',
-            'data'   => $row,
-        ]);
+        $this->testGet($I, ItemType::TABLE, 1);
     }
 
     public function testCreateItemType(ApiTester $I)
     {
         (new ItemTypeControllerSeeder)->run();
-        $numOfRecord = $I->grabNumRecords(ItemType::TABLE);
-
-        $I->sendPOST($this->getBaseUrl(), [
+        $this->testCreate($I, ItemType::TABLE, [
             'description' => 'type 99',
         ]);
-
-        $I->seeResponseCodeIs(200);
-        $I->seeResponseIsJson();
-        $I->seeResponseContainsJson([
-            'status' => 'success',
-            'data'   => [
-                'description' => 'type 99',
-            ],
-        ]);
-        $I->seeNumRecords($numOfRecord + 1, ItemType::TABLE);
     }
 
     public function testCreateItemTypeWithMissingRequiredFields(ApiTester $I)
     {
         (new ItemTypeControllerSeeder)->run();
-        $numOfRecord = $I->grabNumRecords(ItemType::TABLE);
-
-        $I->sendPOST($this->getBaseUrl(), [
-            'nonexistence field' => 'foo',
-        ]);
-
-        $I->seeResponseCodeIs(400);
-        $response = $I->grabJsonResponse();
-        verify($response['status'])->equals('fail');
-        verify($response['data'])->hasKey('description');
-        $I->seeNumRecords($numOfRecord, ItemType::TABLE);
+        $this->testCreateWithMissingRequiredFields($I, ItemType::TABLE, ['description']);
     }
 
     public function testCreateItemTypeWithAlreadyExistType(ApiTester $I)
     {
         (new ItemTypeControllerSeeder)->run();
-        $numOfRecord = $I->grabNumRecords(ItemType::TABLE);
-
-        $I->sendPOST($this->getBaseUrl(), [
+        $this->testCreateWithAlreadyExist($I, ItemType::TABLE, [
             'description' => 'type 1',
         ]);
-
-        $I->seeResponseCodeIs(400);
-        $I->seeResponseIsJson();
-        $response = $I->grabJsonResponse();
-        verify($response['status'])->equals('fail');
-        verify($response['data'])->hasKey('description');
-        $I->seeNumRecords($numOfRecord, ItemType::TABLE);
     }
 
     public function testUpdateItemType(ApiTester $I)
@@ -114,23 +62,9 @@ class ItemTypeCest extends BaseCest
     public function testUpdateItemTypeWithAlreadyExistType(ApiTester $I)
     {
         (new ItemTypeControllerSeeder)->run();
-        $before = $I->grabRecord(ItemType::TABLE, ['id' => 1,]);
-
-        $I->sendPUT("{$this->getBaseUrl()}/1", [
-                'description' => 'type 2',
-            ] + $before
-        );
-
-        $I->seeResponseCodeIs(400);
-        $I->seeResponseIsJson();
-        $response = $I->grabJsonResponse();
-        verify($response['status'])->equals('fail');
-        foreach (['description'] as $field) {
-            verify($response['data'])->hasKey($field);
-            verify($response['data'][$field])->contains(sprintf(ValidationMessage::UNIQUE, str_replace('_', ' ', $field)));
-        }
-        $after = $I->grabRecord(ItemType::TABLE, ['id' => 1,]);
-        verify($before)->equals($after);
+        $this->testUpdateWithAlreadyExist($I, ItemType::TABLE, [
+            'description' => 'type 2',
+        ], 1);
     }
 
     public function testUpdateItemTypeWithoutChangingUniqueField(ApiTester $I)

--- a/tests/api/ItemTypeCest.php
+++ b/tests/api/ItemTypeCest.php
@@ -9,12 +9,12 @@ use App\Tests\ValidationMessage;
 
 class ItemTypeCest extends BaseCest
 {
-    public function getBaseUrl(): string
+    protected function getBaseUrl(): string
     {
         return '/item_types';
     }
 
-    public function createItemTypeWithMissingRequiredFields(ApiTester $I)
+    public function testCreateItemTypeWithMissingRequiredFields(ApiTester $I)
     {
         (new ItemTypeControllerSeeder)->run();
         $numOfRecord = $I->grabNumRecords(ItemType::TABLE);
@@ -23,13 +23,14 @@ class ItemTypeCest extends BaseCest
             'nonexistence field' => 'foo',
         ]);
 
+        $I->seeResponseCodeIs(400);
         $response = $I->grabJsonResponse();
         verify($response['status'])->equals('fail');
         verify($response['data'])->hasKey('description');
         $I->seeNumRecords($numOfRecord, ItemType::TABLE);
     }
 
-    public function createItemType(ApiTester $I)
+    public function testCreateItemType(ApiTester $I)
     {
         (new ItemTypeControllerSeeder)->run();
         $numOfRecord = $I->grabNumRecords(ItemType::TABLE);
@@ -49,7 +50,7 @@ class ItemTypeCest extends BaseCest
         $I->seeNumRecords($numOfRecord + 1, ItemType::TABLE);
     }
 
-    public function createItemTypeWithAlreadyExistType(ApiTester $I)
+    public function testCreateItemTypeWithAlreadyExistType(ApiTester $I)
     {
         (new ItemTypeControllerSeeder)->run();
         $numOfRecord = $I->grabNumRecords(ItemType::TABLE);
@@ -66,7 +67,7 @@ class ItemTypeCest extends BaseCest
         $I->seeNumRecords($numOfRecord, ItemType::TABLE);
     }
 
-    public function updateItemTypeWithAlreadyExistType(ApiTester $I)
+    public function testUpdateItemTypeWithAlreadyExistType(ApiTester $I)
     {
         (new ItemTypeControllerSeeder)->run();
         $before = $I->grabRecord(ItemType::TABLE, ['id' => 1,]);
@@ -88,7 +89,7 @@ class ItemTypeCest extends BaseCest
         verify($before)->equals($after);
     }
 
-    public function updateItemTypeWithoutChangingUniqueField(ApiTester $I)
+    public function testUpdateItemTypeWithoutChangingUniqueField(ApiTester $I)
     {
         (new ItemTypeControllerSeeder)->run();
         $before = $I->grabRecord(ItemType::TABLE, ['id' => 1]);

--- a/tests/api/ItemTypeCest.php
+++ b/tests/api/ItemTypeCest.php
@@ -102,40 +102,13 @@ class ItemTypeCest extends BaseCest
     public function testUpdateItemType(ApiTester $I)
     {
         (new ItemTypeControllerSeeder)->run();
-        $before = $I->grabRecord(ItemType::TABLE, ['id' => 1]);
-
-        $I->sendPUT("{$this->getBaseUrl()}/1", [
-                'description' => 'type 99',
-            ] + $before
-        );
-
-        $I->seeResponseCodeIs(200);
-        $I->seeResponseIsJson();
-        $response = $I->grabJsonResponse();
-        verify($response['status'])->equals('success');
-        $after = $I->grabRecord(ItemType::TABLE, ['id' => 1]);
-        verify($before)->notEquals($after);
-        verify($after['description'])->equals('type 99');
-        verify($response['data'])->equals($after);
+        $this->testUpdate($I, ItemType::TABLE, ['description' => 'type 99'], 1);
     }
 
     public function testUpdateItemTypeWithMissingRequiredFields(ApiTester $I)
     {
         (new ItemTypeControllerSeeder)->run();
-        $before = $I->grabRecord(ItemType::TABLE, ['id' => 1]);
-
-        $I->sendPUT("{$this->getBaseUrl()}/1", []);
-
-        $I->seeResponseCodeIs(400);
-        $I->seeResponseIsJson();
-        $response = $I->grabJsonResponse();
-        verify($response['status'])->equals('fail');
-        foreach (['description'] as $field) {
-            verify($response['data'])->hasKey($field);
-            verify($response['data'][$field])->contains(sprintf(ValidationMessage::REQUIRED, str_replace('_', ' ', $field)));
-        }
-        $after = $I->grabRecord(ItemType::TABLE, ['id' => 1]);
-        verify($before)->equals($after);
+        $this->testUpdateWithMissingRequiredFields($I, ItemType::TABLE, ['description'], 1);
     }
 
     public function testUpdateItemTypeWithAlreadyExistType(ApiTester $I)
@@ -163,31 +136,18 @@ class ItemTypeCest extends BaseCest
     public function testUpdateItemTypeWithoutChangingUniqueField(ApiTester $I)
     {
         (new ItemTypeControllerSeeder)->run();
-        $before = $I->grabRecord(ItemType::TABLE, ['id' => 1]);
+        $this->testUpdateWithoutChangingUniqueFields($I, ItemType::TABLE, 1);
+    }
 
-        $I->sendPUT("{$this->getBaseUrl()}/1", $before);
-
-        $I->seeResponseCodeIs(200);
-        $I->seeResponseIsJson();
-        $I->seeResponseContainsJson([
-            'status' => 'success',
-            'data'   => $before,
-        ]);
+    public function testUpdateItemTypeWithTooLong(ApiTester $I)
+    {
+        (new ItemTypeControllerSeeder)->run();
+        $this->testUpdateWithTooLong($I, ItemType::TABLE, ['description' => 30], 1);
     }
 
     public function testDeleteItemType(ApiTester $I)
     {
         (new ItemTypeControllerSeeder)->run();
-        $before = $I->grabRecord(ItemType::TABLE, ['id' => 1]);
-
-        $I->sendDELETE("{$this->getBaseUrl()}/1");
-
-        $I->seeResponseCodeIs(200);
-        $I->dontSeeInDatabase(ItemType::TABLE, $before);
-        $I->seeResponseIsJson();
-        $I->seeResponseContainsJson([
-            'status' => 'success',
-            'data'   => $before,
-        ]);
+        $this->testDelete($I, ItemType::TABLE, 1);
     }
 }

--- a/tests/api/ItemTypeCest.php
+++ b/tests/api/ItemTypeCest.php
@@ -14,20 +14,36 @@ class ItemTypeCest extends BaseCest
         return '/item_types';
     }
 
-    public function testCreateItemTypeWithMissingRequiredFields(ApiTester $I)
+    public function testGetItemTypes(ApiTester $I)
     {
         (new ItemTypeControllerSeeder)->run();
-        $numOfRecord = $I->grabNumRecords(ItemType::TABLE);
 
-        $I->sendPOST($this->getBaseUrl(), [
-            'nonexistence field' => 'foo',
+        $I->sendGET($this->getBaseUrl());
+
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseIsJson();
+        $I->seeResponseContainsJson([
+            'status' => 'success',
+            'data'   => [
+                ['id' => 1, 'description' => 'type 1'],
+                ['id' => 2, 'description' => 'type 2'],
+            ],
         ]);
+    }
 
-        $I->seeResponseCodeIs(400);
-        $response = $I->grabJsonResponse();
-        verify($response['status'])->equals('fail');
-        verify($response['data'])->hasKey('description');
-        $I->seeNumRecords($numOfRecord, ItemType::TABLE);
+    public function testGetItemType(ApiTester $I)
+    {
+        (new ItemTypeControllerSeeder)->run();
+        $row = $I->grabRecord(ItemType::TABLE, ['id' => 1]);
+
+        $I->sendGET("{$this->getBaseUrl()}/1");
+
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseIsJson();
+        $I->seeResponseContainsJson([
+            'status' => 'success',
+            'data'   => $row,
+        ]);
     }
 
     public function testCreateItemType(ApiTester $I)
@@ -50,6 +66,22 @@ class ItemTypeCest extends BaseCest
         $I->seeNumRecords($numOfRecord + 1, ItemType::TABLE);
     }
 
+    public function testCreateItemTypeWithMissingRequiredFields(ApiTester $I)
+    {
+        (new ItemTypeControllerSeeder)->run();
+        $numOfRecord = $I->grabNumRecords(ItemType::TABLE);
+
+        $I->sendPOST($this->getBaseUrl(), [
+            'nonexistence field' => 'foo',
+        ]);
+
+        $I->seeResponseCodeIs(400);
+        $response = $I->grabJsonResponse();
+        verify($response['status'])->equals('fail');
+        verify($response['data'])->hasKey('description');
+        $I->seeNumRecords($numOfRecord, ItemType::TABLE);
+    }
+
     public function testCreateItemTypeWithAlreadyExistType(ApiTester $I)
     {
         (new ItemTypeControllerSeeder)->run();
@@ -65,6 +97,45 @@ class ItemTypeCest extends BaseCest
         verify($response['status'])->equals('fail');
         verify($response['data'])->hasKey('description');
         $I->seeNumRecords($numOfRecord, ItemType::TABLE);
+    }
+
+    public function testUpdateItemType(ApiTester $I)
+    {
+        (new ItemTypeControllerSeeder)->run();
+        $before = $I->grabRecord(ItemType::TABLE, ['id' => 1]);
+
+        $I->sendPUT("{$this->getBaseUrl()}/1", [
+                'description' => 'type 99',
+            ] + $before
+        );
+
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseIsJson();
+        $response = $I->grabJsonResponse();
+        verify($response['status'])->equals('success');
+        $after = $I->grabRecord(ItemType::TABLE, ['id' => 1]);
+        verify($before)->notEquals($after);
+        verify($after['description'])->equals('type 99');
+        verify($response['data'])->equals($after);
+    }
+
+    public function testUpdateItemTypeWithMissingRequiredFields(ApiTester $I)
+    {
+        (new ItemTypeControllerSeeder)->run();
+        $before = $I->grabRecord(ItemType::TABLE, ['id' => 1]);
+
+        $I->sendPUT("{$this->getBaseUrl()}/1", []);
+
+        $I->seeResponseCodeIs(400);
+        $I->seeResponseIsJson();
+        $response = $I->grabJsonResponse();
+        verify($response['status'])->equals('fail');
+        foreach (['description'] as $field) {
+            verify($response['data'])->hasKey($field);
+            verify($response['data'][$field])->contains(sprintf(ValidationMessage::REQUIRED, str_replace('_', ' ', $field)));
+        }
+        $after = $I->grabRecord(ItemType::TABLE, ['id' => 1]);
+        verify($before)->equals($after);
     }
 
     public function testUpdateItemTypeWithAlreadyExistType(ApiTester $I)
@@ -97,6 +168,22 @@ class ItemTypeCest extends BaseCest
         $I->sendPUT("{$this->getBaseUrl()}/1", $before);
 
         $I->seeResponseCodeIs(200);
+        $I->seeResponseIsJson();
+        $I->seeResponseContainsJson([
+            'status' => 'success',
+            'data'   => $before,
+        ]);
+    }
+
+    public function testDeleteItemType(ApiTester $I)
+    {
+        (new ItemTypeControllerSeeder)->run();
+        $before = $I->grabRecord(ItemType::TABLE, ['id' => 1]);
+
+        $I->sendDELETE("{$this->getBaseUrl()}/1");
+
+        $I->seeResponseCodeIs(200);
+        $I->dontSeeInDatabase(ItemType::TABLE, $before);
         $I->seeResponseIsJson();
         $I->seeResponseContainsJson([
             'status' => 'success',

--- a/tests/api/UnitCest.php
+++ b/tests/api/UnitCest.php
@@ -30,6 +30,20 @@ class UnitCest extends BaseCest
         ]);
     }
 
+    public function testGetUnit(ApiTester $I)
+    {
+        (new UnitControllerSeeder)->run();
+        $row = $I->grabRecord(Unit::TABLE, ['id' => 1]);
+
+        $I->sendGET("{$this->getBaseUrl()}/1");
+
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseJsonEquals([
+            'status' => 'success',
+            'data'   => $row,
+        ]);
+    }
+
     public function testCreateUnit(ApiTester $I)
     {
         (new UnitControllerSeeder)->run();

--- a/tests/api/UnitCest.php
+++ b/tests/api/UnitCest.php
@@ -124,77 +124,30 @@ class UnitCest extends BaseCest
     public function testUpdateUnit(ApiTester $I)
     {
         (new UnitControllerSeeder)->run();
-        $before = $I->grabRecord(Unit::TABLE, ['id' => 1]);
+        $this->testUpdate($I, Unit::TABLE, ['description' => 'updated',], 1);
+    }
 
-        $I->sendPUT("{$this->getBaseUrl()}/1", [
-            'code'        => 'cj1',
-            'description' => 'updated',
-        ]);
-
-        $I->seeResponseCodeIs(200);
-        $I->seeResponseIsJson();
-        $response = $I->grabJsonResponse();
-        verify($response['status'])->equals('success');
-        $after = $I->grabRecord(Unit::TABLE, ['id' => 1]);
-        verify($before)->notEquals($after);
-        verify('Should be unable to update code.', $after['code'])->notEquals('cj1');
-        verify('Should be able to update description.', $after['description'])->equals('updated');
-        verify($response['data'])->equals($after);
+    public function testUpdateUnitWithUnfillableFields(ApiTester $I)
+    {
+        (new UnitControllerSeeder)->run();
+        $this->testUpdateWithUnfillableFields($I, Unit::TABLE, ['code' => 'cj1'], 1);
     }
 
     public function testUpdateUnitWithTooLong(ApiTester $I)
     {
         (new UnitControllerSeeder)->run();
-        $before = $I->grabRecord(Unit::TABLE, ['id' => 1]);
-
-        $I->sendPUT("{$this->getBaseUrl()}/1", [
-            'description' => 'super long unit' . str_repeat('x', 40),
-        ]);
-
-        $I->seeResponseCodeIs(400);
-        $I->seeResponseIsJson();
-        $response = $I->grabJsonResponse();
-        verify($response['status'])->equals('fail');
-        foreach (['description' => 40] as $field => $max) {
-            verify($response['data'])->hasKey($field);
-            verify($response['data'][$field])->contains(sprintf(ValidationMessage::MAX_STRING, str_replace('_', ' ', $field), $max));
-        }
-        $after = $I->grabRecord(Unit::TABLE, ['id' => 1]);
-        verify($before)->equals($after);
+        $this->testUpdateWithTooLong($I, Unit::TABLE, ['description' => 40], 1);
     }
 
     public function testUpdateUnitWithMissingRequiredFields(ApiTester $I)
     {
         (new UnitControllerSeeder)->run();
-        $before = $I->grabRecord(Unit::TABLE, ['id' => 1]);
-
-        $I->sendPUT("{$this->getBaseUrl()}/1", []);
-
-        $I->seeResponseCodeIs(400);
-        $I->seeResponseIsJson();
-        $response = $I->grabJsonResponse();
-        verify($response['status'])->equals('fail');
-        foreach (['description'] as $field) {
-            verify($response['data'])->hasKey($field);
-            verify($response['data'][$field])->contains(sprintf(ValidationMessage::REQUIRED, str_replace('_', ' ', $field)));
-        }
-        $after = $I->grabRecord(Unit::TABLE, ['id' => 1]);
-        verify($before)->equals($after);
+        $this->testUpdateWithMissingRequiredFields($I, Unit::TABLE, ['description'], 1);
     }
 
     public function testDeleteUnit(ApiTester $I)
     {
         (new UnitControllerSeeder)->run();
-        $before = $I->grabRecord(Unit::TABLE, ['id' => 1]);
-
-        $I->sendDELETE("{$this->getBaseUrl()}/1");
-
-        $I->seeResponseCodeIs(200);
-        $I->dontSeeInDatabase(Unit::TABLE, $before);
-        $I->seeResponseIsJson();
-        $I->seeResponseContainsJson([
-            'status' => 'success',
-            'data'   => $before,
-        ]);
+        $this->testDelete($I, Unit::TABLE, 1);
     }
 }

--- a/tests/api/UnitCest.php
+++ b/tests/api/UnitCest.php
@@ -9,12 +9,12 @@ use App\Tests\ValidationMessage;
 
 class UnitCest extends BaseCest
 {
-    public function getBaseUrl(): string
+    protected function getBaseUrl(): string
     {
         return '/units';
     }
 
-    public function getUnits(ApiTester $I)
+    public function testGetUnits(ApiTester $I)
     {
         (new UnitControllerSeeder)->run();
 
@@ -30,7 +30,7 @@ class UnitCest extends BaseCest
         ]);
     }
 
-    public function createUnit(ApiTester $I)
+    public function testCreateUnit(ApiTester $I)
     {
         (new UnitControllerSeeder)->run();
         $numOfRecords = $I->grabNumRecords(Unit::TABLE);
@@ -49,7 +49,7 @@ class UnitCest extends BaseCest
         $I->seeNumRecords($numOfRecords + 1, Unit::TABLE);
     }
 
-    public function createUnitWithMissingRequiredFields(ApiTester $I)
+    public function testCreateUnitWithMissingRequiredFields(ApiTester $I)
     {
         (new UnitControllerSeeder)->run();
         $numOfRecords = $I->grabNumRecords(Unit::TABLE);
@@ -67,7 +67,7 @@ class UnitCest extends BaseCest
         $I->seeNumRecords($numOfRecords, Unit::TABLE);
     }
 
-    public function createUnitWithAlreadyExistCode(ApiTester $I)
+    public function testCreateUnitWithAlreadyExistCode(ApiTester $I)
     {
         (new UnitControllerSeeder)->run();
         $numOfRecords = $I->grabNumRecords(Unit::TABLE);
@@ -86,7 +86,7 @@ class UnitCest extends BaseCest
         $I->seeNumRecords($numOfRecords, Unit::TABLE);
     }
 
-    public function createUnitWithTooLong(ApiTester $I)
+    public function testCreateUnitWithTooLong(ApiTester $I)
     {
         (new UnitControllerSeeder)->run();
         $numOfRecords = $I->grabNumRecords(Unit::TABLE);
@@ -107,7 +107,7 @@ class UnitCest extends BaseCest
         $I->seeNumRecords($numOfRecords, Unit::TABLE);
     }
 
-    public function updateUnit(ApiTester $I)
+    public function testUpdateUnit(ApiTester $I)
     {
         (new UnitControllerSeeder)->run();
 
@@ -129,7 +129,7 @@ class UnitCest extends BaseCest
         ]);
     }
 
-    public function updateUnitWithTooLong(ApiTester $I)
+    public function testUpdateUnitWithTooLong(ApiTester $I)
     {
         (new UnitControllerSeeder)->run();
 
@@ -150,7 +150,7 @@ class UnitCest extends BaseCest
         ]);
     }
 
-    public function deleteUnit(ApiTester $I)
+    public function testDeleteUnit(ApiTester $I)
     {
         (new UnitControllerSeeder)->run();
 


### PR DESCRIPTION
feat:
- single get api

fix:
- we use `fresh()` so that the system return every fields in the model not just the fields that are in payload pass in the model during initialization.

test:
- add missing tests
- refactor test pattern